### PR TITLE
Remove text-selection from banner shapes

### DIFF
--- a/packages/site/assets/css/style.css
+++ b/packages/site/assets/css/style.css
@@ -1236,6 +1236,10 @@ label input[type="radio"] {
   }
 }
 
+.banner-shape-wrap {
+  user-select: none;
+}
+
 .banner-shape-inner .shape {
   position: absolute;
   -webkit-animation-duration: 3s;


### PR DESCRIPTION
Fixes #29 

Remove text-selection from the animated shapes in the banner component.